### PR TITLE
Add config files for real-world firmware

### DIFF
--- a/fuzzing/configs/Console.cfg
+++ b/fuzzing/configs/Console.cfg
@@ -1,0 +1,65 @@
+#  Copyright (C) 2018-2020 RiS3 Lab
+
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+
+#    http://www.apache.org/licenses/LICENSE-2.0
+
+# Please change configurations that are enclosed in "< >".
+# Please use absolute path in this file.
+
+[DEFAULT] # used only by fuzz.py
+# <repo_path> is the path of root directory of P2IM git repo
+base        = /root/p2im/ 
+# <firmware_name> can be arbitrary string you want. It doesn't need to be the firmware binary name
+program     = console
+# Each firmware may be fuzzed multiple times. So it's better to number each fuzzer run
+run         = 01
+# working directory of fuzzing
+working_dir = %(base)s/fuzzing/%(program)s/%(run)s
+
+[afl] # used only by fuzz.py
+bin         = %(base)s/afl/afl-fuzz
+timeout     = 150+
+input       = %(working_dir)s/inputs
+output      = %(working_dir)s/outputs
+
+[cov] # used only by cov.py
+#count_hang  = False
+count_hang  = True
+bbl_cov_read_sz = 20000000
+# 1 second
+timeout     = 1
+
+[qemu]
+bin         = %(base)s/qemu/precompiled_bin/qemu-system-gnuarmeclipse
+log         = unimp,guest_errors,int
+#log         = unimp,guest_errors,exec,int -D qemu.log
+
+[program]
+# the board/mcu supported by QEMU is listed as comments below
+board       = FRDM-K64F
+mcu         = MK64FN1M0VLL12
+
+#board       = STM32F429I-Discovery
+#mcu         = STM32F429ZI
+#board       = NUCLEO-F103RB
+#mcu         = STM32F103RB
+#board       = Arduino-Due
+#mcu         = SAM3X8E
+#board       = FRDM-K64F
+#mcu         = MK64FN1M0VLL12
+
+# <firmware_elf_file_name> has to be name of firmware elf file
+img         = %(working_dir)s/Console
+
+[model]
+retry_num   = 3
+peri_addr_range = 512
+# arm-none-eabi-objdump is part of GNU Arm Embedded Toolchain you downloaded while setting up P2IM environment.
+# For example, <path_of_arm-none-eabi-objdump> on my machine is /home/bo/gcc-arm-none-eabi-6-2017-q2-update/bin/arm-none-eabi-objdump
+objdump     = /root/gcc-arm-none-eabi-10-2020-q4-major/bin/arm-none-eabi-objdump
+# config below are only used by fuzz.py
+bin         = %(base)s/model_instantiation/me.py
+log_file    = %(working_dir)s/me.log

--- a/fuzzing/configs/Console.cfg
+++ b/fuzzing/configs/Console.cfg
@@ -57,8 +57,6 @@ img         = %(working_dir)s/Console
 [model]
 retry_num   = 3
 peri_addr_range = 512
-# arm-none-eabi-objdump is part of GNU Arm Embedded Toolchain you downloaded while setting up P2IM environment.
-# For example, <path_of_arm-none-eabi-objdump> on my machine is /home/bo/gcc-arm-none-eabi-6-2017-q2-update/bin/arm-none-eabi-objdump
 objdump     = /root/gcc-arm-none-eabi-10-2020-q4-major/bin/arm-none-eabi-objdump
 # config below are only used by fuzz.py
 bin         = %(base)s/model_instantiation/me.py

--- a/fuzzing/configs/Heat_Press.cfg
+++ b/fuzzing/configs/Heat_Press.cfg
@@ -1,0 +1,64 @@
+#  Copyright (C) 2018-2020 RiS3 Lab
+
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+
+#    http://www.apache.org/licenses/LICENSE-2.0
+
+# Please change configurations that are enclosed in "< >".
+# Please use absolute path in this file.
+
+[DEFAULT] # used only by fuzz.py
+# <repo_path> is the path of root directory of P2IM git repo
+base        = /root/p2im
+# <firmware_name> can be arbitrary string you want. It doesn't need to be the firmware binary name
+program     = heat_press
+# Each firmware may be fuzzed multiple times. So it's better to number each fuzzer run
+run         = 01
+# working directory of fuzzing
+working_dir = %(base)s/fuzzing/%(program)s/%(run)s
+
+[afl] # used only by fuzz.py
+bin         = %(base)s/afl/afl-fuzz
+timeout     = 150+
+input       = %(working_dir)s/inputs
+output      = %(working_dir)s/outputs
+
+[cov] # used only by cov.py
+#count_hang  = False
+count_hang  = True
+bbl_cov_read_sz = 20000000
+# 1 second
+timeout     = 1
+
+[qemu]
+bin         = %(base)s/qemu/precompiled_bin/qemu-system-gnuarmeclipse
+log         = unimp,guest_errors,int
+#log         = unimp,guest_errors,exec,int -D qemu.log
+
+[program]
+# the board/mcu supported by QEMU is listed as comments below
+board       = Arduino-Due
+mcu         = SAM3X8E
+
+#board       = STM32F429I-Discovery
+#mcu         = STM32F429ZI
+#board       = NUCLEO-F103RB
+#mcu         = STM32F103RB
+#board       = Arduino-Due
+#mcu         = SAM3X8E
+#board       = FRDM-K64F
+#mcu         = MK64FN1M0VLL12
+
+
+# <firmware_elf_file_name> has to be name of firmware elf file
+img         = %(working_dir)s/Heat_Press
+
+[model]
+retry_num   = 3
+peri_addr_range = 512
+objdump     = /root/gcc-arm-none-eabi-10-2020-q4-major/bin/arm-none-eabi-objdump
+# config below are only used by fuzz.py
+bin         = %(base)s/model_instantiation/me.py
+log_file    = %(working_dir)s/me.log

--- a/fuzzing/configs/PLC.cfg
+++ b/fuzzing/configs/PLC.cfg
@@ -1,0 +1,64 @@
+#  Copyright (C) 2018-2020 RiS3 Lab
+
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+
+#    http://www.apache.org/licenses/LICENSE-2.0
+
+# Please change configurations that are enclosed in "< >".
+# Please use absolute path in this file.
+
+[DEFAULT] # used only by fuzz.py
+# <repo_path> is the path of root directory of P2IM git repo
+base        = /root/p2im
+# <firmware_name> can be arbitrary string you want. It doesn't need to be the firmware binary name
+program     = plc
+# Each firmware may be fuzzed multiple times. So it's better to number each fuzzer run
+run         = 01
+# working directory of fuzzing
+working_dir = %(base)s/fuzzing/%(program)s/%(run)s
+
+[afl] # used only by fuzz.py
+bin         = %(base)s/afl/afl-fuzz
+timeout     = 150+
+input       = %(working_dir)s/inputs
+output      = %(working_dir)s/outputs
+
+[cov] # used only by cov.py
+#count_hang  = False
+count_hang  = True
+bbl_cov_read_sz = 20000000
+# 1 second
+timeout     = 1
+
+[qemu]
+bin         = %(base)s/qemu/precompiled_bin/qemu-system-gnuarmeclipse
+log         = unimp,guest_errors,int
+#log         = unimp,guest_errors,exec,int -D qemu.log
+
+[program]
+# the board/mcu supported by QEMU is listed as comments below
+board       = STM32F429I-Discovery
+mcu         = STM32F429ZI
+
+#board       = STM32F429I-Discovery
+#mcu         = STM32F429ZI
+#board       = NUCLEO-F103RB
+#mcu         = STM32F103RB
+#board       = Arduino-Due
+#mcu         = SAM3X8E
+#board       = FRDM-K64F
+#mcu         = MK64FN1M0VLL12
+
+
+# <firmware_elf_file_name> has to be name of firmware elf file
+img         = %(working_dir)s/PLC
+
+[model]
+retry_num   = 3
+peri_addr_range = 512
+objdump     = /root/gcc-arm-none-eabi-10-2020-q4-major/bin/arm-none-eabi-objdump
+# config below are only used by fuzz.py
+bin         = %(base)s/model_instantiation/me.py
+log_file    = %(working_dir)s/me.log

--- a/fuzzing/configs/Robot.cfg
+++ b/fuzzing/configs/Robot.cfg
@@ -1,0 +1,64 @@
+#  Copyright (C) 2018-2020 RiS3 Lab
+
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+
+#    http://www.apache.org/licenses/LICENSE-2.0
+
+# Please change configurations that are enclosed in "< >".
+# Please use absolute path in this file.
+
+[DEFAULT] # used only by fuzz.py
+# <repo_path> is the path of root directory of P2IM git repo
+base        = /root/p2im
+# <firmware_name> can be arbitrary string you want. It doesn't need to be the firmware binary name
+program     = robot
+# Each firmware may be fuzzed multiple times. So it's better to number each fuzzer run
+run         = 01
+# working directory of fuzzing
+working_dir = %(base)s/fuzzing/%(program)s/%(run)s
+
+[afl] # used only by fuzz.py
+bin         = %(base)s/afl/afl-fuzz
+timeout     = 150+
+input       = %(working_dir)s/inputs
+output      = %(working_dir)s/outputs
+
+[cov] # used only by cov.py
+#count_hang  = False
+count_hang  = True
+bbl_cov_read_sz = 20000000
+# 1 second
+timeout     = 1
+
+[qemu]
+bin         = %(base)s/qemu/precompiled_bin/qemu-system-gnuarmeclipse
+log         = unimp,guest_errors,int
+#log         = unimp,guest_errors,exec,int -D qemu.log
+
+[program]
+# the board/mcu supported by QEMU is listed as comments below
+board       = NUCLEO-F103RB
+mcu         = STM32F103RB
+
+#board       = STM32F429I-Discovery
+#mcu         = STM32F429ZI
+#board       = NUCLEO-F103RB
+#mcu         = STM32F103RB
+#board       = Arduino-Due
+#mcu         = SAM3X8E
+#board       = FRDM-K64F
+#mcu         = MK64FN1M0VLL12
+
+
+# <firmware_elf_file_name> has to be name of firmware elf file
+img         = %(working_dir)s/Robot
+
+[model]
+retry_num   = 3
+peri_addr_range = 512
+objdump     = /root/gcc-arm-none-eabi-10-2020-q4-major/bin/arm-none-eabi-objdump
+# config below are only used by fuzz.py
+bin         = %(base)s/model_instantiation/me.py
+log_file    = %(working_dir)s/me.log

--- a/fuzzing/configs/fuzz.cfg
+++ b/fuzzing/configs/fuzz.cfg
@@ -1,0 +1,64 @@
+#  Copyright (C) 2018-2020 RiS3 Lab
+
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+
+#    http://www.apache.org/licenses/LICENSE-2.0
+
+# Please change configurations that are enclosed in "< >".
+# Please use absolute path in this file.
+
+[DEFAULT] # used only by fuzz.py
+# <repo_path> is the path of root directory of P2IM git repo
+base        = /root/p2im
+# <firmware_name> can be arbitrary string you want. It doesn't need to be the firmware binary name
+program     = <firmware_name>
+# Each firmware may be fuzzed multiple times. So it's better to number each fuzzer run
+run         = 01
+# working directory of fuzzing
+working_dir = %(base)s/fuzzing/%(program)s/%(run)s
+
+[afl] # used only by fuzz.py
+bin         = %(base)s/afl/afl-fuzz
+timeout     = 150+
+input       = %(working_dir)s/inputs
+output      = %(working_dir)s/outputs
+
+[cov] # used only by cov.py
+#count_hang  = False
+count_hang  = True
+bbl_cov_read_sz = 20000000
+# 1 second
+timeout     = 1
+
+[qemu]
+bin         = %(base)s/qemu/precompiled_bin/qemu-system-gnuarmeclipse
+log         = unimp,guest_errors,int
+#log         = unimp,guest_errors,exec,int -D qemu.log
+
+[program]
+# the board/mcu supported by QEMU is listed as comments below
+board       = <board_name>
+mcu         = <mcu_name>
+
+#board       = STM32F429I-Discovery
+#mcu         = STM32F429ZI
+#board       = NUCLEO-F103RB
+#mcu         = STM32F103RB
+#board       = Arduino-Due
+#mcu         = SAM3X8E
+#board       = FRDM-K64F
+#mcu         = MK64FN1M0VLL12
+
+
+# <firmware_elf_file_name> has to be name of firmware elf file
+img         = %(working_dir)s/<firmware_elf_file_name>
+
+[model]
+retry_num   = 3
+peri_addr_range = 512
+objdump     = /root/gcc-arm-none-eabi-10-2020-q4-major/bin/arm-none-eabi-objdump
+# config below are only used by fuzz.py
+bin         = %(base)s/model_instantiation/me.py
+log_file    = %(working_dir)s/me.log


### PR DESCRIPTION
It's convenient to have some configs files
completed in order to create out-of-the-box
fuzzing examples within a docker.