### PR TITLE
Setup dockerfile to test P2IM

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,41 @@
+FROM ubuntu:16.04
+ARG VERSION=1
+
+LABEL author="andreia.ocanoaia@gmail.com" \
+      name="P2IM Testing" \
+      version="${VERSION}"
+
+WORKDIR /root/
+
+# Install missing packages and required dependencies
+RUN apt-get update && \
+    DEBIAN_FRONTEND="noninteractive" apt-get install -y wget vim ssh git python3 python3-pip \
+    libboost-all-dev libz3-dev cmake
+
+# Clone P2IM and it's submodules
+RUN git clone --recursive https://github.com/andreia-oca/p2im.git p2im
+
+# Compile AFL
+RUN ["/bin/bash", "-c", "cd /root/p2im && make -C afl/"]
+
+# Download and install GNU Arn Enbedded Toolchain
+RUN wget "https://developer.arm.com/-/media/Files/downloads/gnu-rm/10-2020q4/gcc-arm-none-eabi-10-2020-q4-major-x86_64-linux.tar.bz2?revision=ca0cbf9c-9de2-491c-ac48-898b5bbc0443&la=en&hash=68760A8AE66026BCF99F05AC017A6A50C6FD832A" -O "gcc-arm-none-eabi-10-2020-q4-major.tar.bz2"
+RUN tar xjf gcc-arm-none-eabi-10-2020-q4-major.tar.bz2
+ENV PATH=$PATH:/root/gcc-arm-none-eabi-10-2020-q4-major/bin/
+
+# Uncomment the following lines to ignore the 
+# errors/warnings about crashes and cpu clock frequency coming from AFL. 
+# After changing this file recompile it with `make build`.
+# ENV AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES=1
+# ENV AFL_SKIP_CPUFREQ=1
+
+# Fuzz with AFL on a precompiled, real world firmware 
+# found in P2IM github repo.
+ENV WORKING_DIR=/root/p2im/fuzzing/heat_press/01
+RUN mkdir -p $WORKING_DIR
+RUN cp /root/p2im/fuzzing/configs/Heat_Press.cfg $WORKING_DIR/fuzz.cfg
+RUN cp -r /root/p2im/fuzzing/templates/seeds/ $WORKING_DIR/inputs
+RUN cp /root/p2im/externals/p2im-real_firmware/binary/Heat_Press $WORKING_DIR/
+
+# Run example test when container starts
+CMD /root/p2im/model_instantiation/fuzz.py -c $WORKING_DIR/fuzz.cfg

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,0 +1,17 @@
+version=0.1
+
+build:
+	docker image build -t p2im_img:${version} --build-arg VERSION=${version} .
+
+test: build
+	docker run --rm --name p2im_temp p2im_img:${version}
+
+run: build
+	docker run -it --name p2im p2im_img:${version} /bin/bash
+
+bash:
+	docker exec -it p2im /bin/bash
+
+clean:
+	docker rm -f p2im
+	docker image rm p2im_img:${version}

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,54 @@
+# Testing using `docker`
+
+**NOTE:** Run the following commands on the **host machine** to stop AFL from
+complaining:
+```
+su -
+echo core >/proc/sys/kernel/core_pattern
+cd /sys/devices/system/cpu
+echo performance | tee cpu*/cpufreq/scaling_governor
+exit
+```
+
+The `Dockerfile` provided builds an image with all the required dependencies to run P2IM.
+The `Dockerfile` can be found in the `docker/` folder.
+Inside the `docker/` folder the following files:
+
+* The `Dockerfile` that builds the image
+* A `Makefile` for convenience
+* A configuration file to run P2IM on a real-world firmware
+
+To build the image navigate to the `docker/` directory and run `make`:
+```
+$ cd path/to/p2im/docker/
+$ make
+```
+
+This will build the docker image locally.
+View the available images with:
+```
+$ docker image ls
+```
+
+To start a self-destructing container that runs a simple test, run:
+```
+$ make test
+```
+
+This will run P2IM on a precompiled, real-world firmware provided in 
+the repo at `externals/p2im-real_firmware/binary`.
+
+To start a long running container with an interactive `/bin/bash` session, run:
+```
+$ make run
+```
+
+To connect to an existing, long running container, run:
+```
+$ make bash
+```
+
+To delete the container and local image crated, run:
+```
+$ make clean
+```

--- a/fuzzing/configs/Console.cfg
+++ b/fuzzing/configs/Console.cfg
@@ -1,0 +1,63 @@
+#  Copyright (C) 2018-2020 RiS3 Lab
+
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+
+#    http://www.apache.org/licenses/LICENSE-2.0
+
+# Please change configurations that are enclosed in "< >".
+# Please use absolute path in this file.
+
+[DEFAULT] # used only by fuzz.py
+# <repo_path> is the path of root directory of P2IM git repo
+base        = /root/p2im/ 
+# <firmware_name> can be arbitrary string you want. It doesn't need to be the firmware binary name
+program     = console
+# Each firmware may be fuzzed multiple times. So it's better to number each fuzzer run
+run         = 01
+# working directory of fuzzing
+working_dir = %(base)s/fuzzing/%(program)s/%(run)s
+
+[afl] # used only by fuzz.py
+bin         = %(base)s/afl/afl-fuzz
+timeout     = 150+
+input       = %(working_dir)s/inputs
+output      = %(working_dir)s/outputs
+
+[cov] # used only by cov.py
+#count_hang  = False
+count_hang  = True
+bbl_cov_read_sz = 20000000
+# 1 second
+timeout     = 1
+
+[qemu]
+bin         = %(base)s/qemu/precompiled_bin/qemu-system-gnuarmeclipse
+log         = unimp,guest_errors,int
+#log         = unimp,guest_errors,exec,int -D qemu.log
+
+[program]
+# the board/mcu supported by QEMU is listed as comments below
+board       = FRDM-K64F
+mcu         = MK64FN1M0VLL12
+
+#board       = STM32F429I-Discovery
+#mcu         = STM32F429ZI
+#board       = NUCLEO-F103RB
+#mcu         = STM32F103RB
+#board       = Arduino-Due
+#mcu         = SAM3X8E
+#board       = FRDM-K64F
+#mcu         = MK64FN1M0VLL12
+
+# <firmware_elf_file_name> has to be name of firmware elf file
+img         = %(working_dir)s/Console
+
+[model]
+retry_num   = 3
+peri_addr_range = 512
+objdump     = /root/gcc-arm-none-eabi-10-2020-q4-major/bin/arm-none-eabi-objdump
+# config below are only used by fuzz.py
+bin         = %(base)s/model_instantiation/me.py
+log_file    = %(working_dir)s/me.log

--- a/fuzzing/configs/Heat_Press.cfg
+++ b/fuzzing/configs/Heat_Press.cfg
@@ -1,0 +1,64 @@
+#  Copyright (C) 2018-2020 RiS3 Lab
+
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+
+#    http://www.apache.org/licenses/LICENSE-2.0
+
+# Please change configurations that are enclosed in "< >".
+# Please use absolute path in this file.
+
+[DEFAULT] # used only by fuzz.py
+# <repo_path> is the path of root directory of P2IM git repo
+base        = /root/p2im
+# <firmware_name> can be arbitrary string you want. It doesn't need to be the firmware binary name
+program     = heat_press
+# Each firmware may be fuzzed multiple times. So it's better to number each fuzzer run
+run         = 01
+# working directory of fuzzing
+working_dir = %(base)s/fuzzing/%(program)s/%(run)s
+
+[afl] # used only by fuzz.py
+bin         = %(base)s/afl/afl-fuzz
+timeout     = 150+
+input       = %(working_dir)s/inputs
+output      = %(working_dir)s/outputs
+
+[cov] # used only by cov.py
+#count_hang  = False
+count_hang  = True
+bbl_cov_read_sz = 20000000
+# 1 second
+timeout     = 1
+
+[qemu]
+bin         = %(base)s/qemu/precompiled_bin/qemu-system-gnuarmeclipse
+log         = unimp,guest_errors,int
+#log         = unimp,guest_errors,exec,int -D qemu.log
+
+[program]
+# the board/mcu supported by QEMU is listed as comments below
+board       = Arduino-Due
+mcu         = SAM3X8E
+
+#board       = STM32F429I-Discovery
+#mcu         = STM32F429ZI
+#board       = NUCLEO-F103RB
+#mcu         = STM32F103RB
+#board       = Arduino-Due
+#mcu         = SAM3X8E
+#board       = FRDM-K64F
+#mcu         = MK64FN1M0VLL12
+
+
+# <firmware_elf_file_name> has to be name of firmware elf file
+img         = %(working_dir)s/Heat_Press
+
+[model]
+retry_num   = 3
+peri_addr_range = 512
+objdump     = /root/gcc-arm-none-eabi-10-2020-q4-major/bin/arm-none-eabi-objdump
+# config below are only used by fuzz.py
+bin         = %(base)s/model_instantiation/me.py
+log_file    = %(working_dir)s/me.log

--- a/fuzzing/configs/PLC.cfg
+++ b/fuzzing/configs/PLC.cfg
@@ -1,0 +1,64 @@
+#  Copyright (C) 2018-2020 RiS3 Lab
+
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+
+#    http://www.apache.org/licenses/LICENSE-2.0
+
+# Please change configurations that are enclosed in "< >".
+# Please use absolute path in this file.
+
+[DEFAULT] # used only by fuzz.py
+# <repo_path> is the path of root directory of P2IM git repo
+base        = /root/p2im
+# <firmware_name> can be arbitrary string you want. It doesn't need to be the firmware binary name
+program     = plc
+# Each firmware may be fuzzed multiple times. So it's better to number each fuzzer run
+run         = 01
+# working directory of fuzzing
+working_dir = %(base)s/fuzzing/%(program)s/%(run)s
+
+[afl] # used only by fuzz.py
+bin         = %(base)s/afl/afl-fuzz
+timeout     = 150+
+input       = %(working_dir)s/inputs
+output      = %(working_dir)s/outputs
+
+[cov] # used only by cov.py
+#count_hang  = False
+count_hang  = True
+bbl_cov_read_sz = 20000000
+# 1 second
+timeout     = 1
+
+[qemu]
+bin         = %(base)s/qemu/precompiled_bin/qemu-system-gnuarmeclipse
+log         = unimp,guest_errors,int
+#log         = unimp,guest_errors,exec,int -D qemu.log
+
+[program]
+# the board/mcu supported by QEMU is listed as comments below
+board       = STM32F429I-Discovery
+mcu         = STM32F429ZI
+
+#board       = STM32F429I-Discovery
+#mcu         = STM32F429ZI
+#board       = NUCLEO-F103RB
+#mcu         = STM32F103RB
+#board       = Arduino-Due
+#mcu         = SAM3X8E
+#board       = FRDM-K64F
+#mcu         = MK64FN1M0VLL12
+
+
+# <firmware_elf_file_name> has to be name of firmware elf file
+img         = %(working_dir)s/PLC
+
+[model]
+retry_num   = 3
+peri_addr_range = 512
+objdump     = /root/gcc-arm-none-eabi-10-2020-q4-major/bin/arm-none-eabi-objdump
+# config below are only used by fuzz.py
+bin         = %(base)s/model_instantiation/me.py
+log_file    = %(working_dir)s/me.log

--- a/fuzzing/configs/Robot.cfg
+++ b/fuzzing/configs/Robot.cfg
@@ -1,0 +1,64 @@
+#  Copyright (C) 2018-2020 RiS3 Lab
+
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+
+#    http://www.apache.org/licenses/LICENSE-2.0
+
+# Please change configurations that are enclosed in "< >".
+# Please use absolute path in this file.
+
+[DEFAULT] # used only by fuzz.py
+# <repo_path> is the path of root directory of P2IM git repo
+base        = /root/p2im
+# <firmware_name> can be arbitrary string you want. It doesn't need to be the firmware binary name
+program     = robot
+# Each firmware may be fuzzed multiple times. So it's better to number each fuzzer run
+run         = 01
+# working directory of fuzzing
+working_dir = %(base)s/fuzzing/%(program)s/%(run)s
+
+[afl] # used only by fuzz.py
+bin         = %(base)s/afl/afl-fuzz
+timeout     = 150+
+input       = %(working_dir)s/inputs
+output      = %(working_dir)s/outputs
+
+[cov] # used only by cov.py
+#count_hang  = False
+count_hang  = True
+bbl_cov_read_sz = 20000000
+# 1 second
+timeout     = 1
+
+[qemu]
+bin         = %(base)s/qemu/precompiled_bin/qemu-system-gnuarmeclipse
+log         = unimp,guest_errors,int
+#log         = unimp,guest_errors,exec,int -D qemu.log
+
+[program]
+# the board/mcu supported by QEMU is listed as comments below
+board       = NUCLEO-F103RB
+mcu         = STM32F103RB
+
+#board       = STM32F429I-Discovery
+#mcu         = STM32F429ZI
+#board       = NUCLEO-F103RB
+#mcu         = STM32F103RB
+#board       = Arduino-Due
+#mcu         = SAM3X8E
+#board       = FRDM-K64F
+#mcu         = MK64FN1M0VLL12
+
+
+# <firmware_elf_file_name> has to be name of firmware elf file
+img         = %(working_dir)s/Robot
+
+[model]
+retry_num   = 3
+peri_addr_range = 512
+objdump     = /root/gcc-arm-none-eabi-10-2020-q4-major/bin/arm-none-eabi-objdump
+# config below are only used by fuzz.py
+bin         = %(base)s/model_instantiation/me.py
+log_file    = %(working_dir)s/me.log

--- a/fuzzing/configs/fuzz.cfg
+++ b/fuzzing/configs/fuzz.cfg
@@ -1,0 +1,64 @@
+#  Copyright (C) 2018-2020 RiS3 Lab
+
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+
+#    http://www.apache.org/licenses/LICENSE-2.0
+
+# Please change configurations that are enclosed in "< >".
+# Please use absolute path in this file.
+
+[DEFAULT] # used only by fuzz.py
+# <repo_path> is the path of root directory of P2IM git repo
+base        = /root/p2im
+# <firmware_name> can be arbitrary string you want. It doesn't need to be the firmware binary name
+program     = <firmware_name>
+# Each firmware may be fuzzed multiple times. So it's better to number each fuzzer run
+run         = 01
+# working directory of fuzzing
+working_dir = %(base)s/fuzzing/%(program)s/%(run)s
+
+[afl] # used only by fuzz.py
+bin         = %(base)s/afl/afl-fuzz
+timeout     = 150+
+input       = %(working_dir)s/inputs
+output      = %(working_dir)s/outputs
+
+[cov] # used only by cov.py
+#count_hang  = False
+count_hang  = True
+bbl_cov_read_sz = 20000000
+# 1 second
+timeout     = 1
+
+[qemu]
+bin         = %(base)s/qemu/precompiled_bin/qemu-system-gnuarmeclipse
+log         = unimp,guest_errors,int
+#log         = unimp,guest_errors,exec,int -D qemu.log
+
+[program]
+# the board/mcu supported by QEMU is listed as comments below
+board       = <board_name>
+mcu         = <mcu_name>
+
+#board       = STM32F429I-Discovery
+#mcu         = STM32F429ZI
+#board       = NUCLEO-F103RB
+#mcu         = STM32F103RB
+#board       = Arduino-Due
+#mcu         = SAM3X8E
+#board       = FRDM-K64F
+#mcu         = MK64FN1M0VLL12
+
+
+# <firmware_elf_file_name> has to be name of firmware elf file
+img         = %(working_dir)s/<firmware_elf_file_name>
+
+[model]
+retry_num   = 3
+peri_addr_range = 512
+objdump     = /root/gcc-arm-none-eabi-10-2020-q4-major/bin/arm-none-eabi-objdump
+# config below are only used by fuzz.py
+bin         = %(base)s/model_instantiation/me.py
+log_file    = %(working_dir)s/me.log


### PR DESCRIPTION
Added a Dockerfile to easily build P2IM project.
Furthermore, a real world firmware is provided to test P2IM out-of-the-box. 